### PR TITLE
Remove "Learn More" button

### DIFF
--- a/lib/custom_helpers.rb
+++ b/lib/custom_helpers.rb
@@ -12,7 +12,6 @@ module CustomHelpers
           </div>
           <div class="panel-body">
             <p>#{description}</p>
-            <a href="#{link}" class="btn btn-default">Learn More</a>
           </div>
         </div>
       </div>

--- a/lib/custom_helpers.rb
+++ b/lib/custom_helpers.rb
@@ -17,5 +17,5 @@ module CustomHelpers
       </div>
     EOS
   end
-  
+
 end

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -25,7 +25,7 @@
     <div class="container">
       <div class="row">
         <div class="col-lg-12">
-          
+
           <a href="/"><%= image_tag('logo.svg', :alt => 'RxSwiftCommunity Logo', :class => 'logo') %></a>
 
           <h1><%= title %></h1>


### PR DESCRIPTION
This seems redundant to the project title link.