### PR TITLE
Change README header link to HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[community.rxswift.org](https://community.rxswift.org)
+[community.rxswift.org](http://community.rxswift.org)
 =========================================================
 
 [![Build Status](https://travis-ci.org/RxSwiftCommunity/rxswiftcommunity.github.io.svg?branch=source)](https://travis-ci.org/RxSwiftCommunity/rxswiftcommunity.github.io)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Build Status](https://travis-ci.org/RxSwiftCommunity/rxswiftcommunity.github.io.svg?branch=source)](https://travis-ci.org/RxSwiftCommunity/rxswiftcommunity.github.io)
 
-<img src=source/images/logo.svg height=250 />
+<img src="https://raw.githubusercontent.com/RxSwiftCommunity/rxswiftcommunity.github.io/source/source/images/logo.svg" height="250" />
 
 <br/>
 Website for projects that support RxSwift.


### PR DESCRIPTION
HTTPS is broken for gh-pages with custom domains