### PR TITLE
Direct middleman-gh-pages to master branch.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gem 'middleman'
 
 # Publish to github pages
-gem 'middleman-gh-pages', git: 'https://github.com/josephholsten/middleman-gh-pages.git', branch: 'support-master-branch'
+gem 'middleman-gh-pages', git: 'https://github.com/josephholsten/middleman-gh-pages.git', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/josephholsten/middleman-gh-pages.git
-  revision: ba53204cc06398b045c215271cd5abe5d3e1aff1
-  branch: support-master-branch
+  revision: 2f5522a4745b7e619d1e76e54a191fd15721bca9
+  branch: master
   specs:
     middleman-gh-pages (0.0.3)
       rake (> 0.9.3)


### PR DESCRIPTION
It is currently pointing to a non-existing `support-master-branch` branch