### PR TITLE
Add RxSwift Unofficial Chinese Documentation.

### DIFF
--- a/data/items.yml
+++ b/data/items.yml
@@ -125,3 +125,9 @@ sections:
       - name: ReactiveCommander
         link: https://github.com/SwiftReactive/ReactiveCommander
         description: ReactiveCommander implements the Commands Pattern using NSOperation and NSOperationQueue extensions exposing a Reactive interface.
+
+  - name: Documentation & Resources
+    items:
+      - name: Chinese Documentation (Unofficial)
+        link: https://beeth0ven.github.io/RxSwift-Chinese-Documentation/
+        description: An unofficial RxSwift chinese documentation website which is published with Gitbook (RxSwift 非官方中文文档).

--- a/data/items.yml
+++ b/data/items.yml
@@ -128,6 +128,6 @@ sections:
 
   - name: Documentation & Resources
     items:
-      - name: Chinese Documentation (Unofficial)
-        link: https://beeth0ven.github.io/RxSwift-Chinese-Documentation/
-        description: An unofficial RxSwift chinese documentation website which is published with Gitbook (RxSwift 非官方中文文档).
+      - name: RxSwift 中文文档（非官方）
+        link: https://beeth0ven.github.io/RxSwift-Chinese-Documentation
+        description: An unofficial RxSwift Chinese documentation website which is published with Gitbook.


### PR DESCRIPTION
This documentation will make Chinese to get start with RxSwift much easier.

Er, currently it does not look good by using long title:

![2017-09-05 10 28 01](https://user-images.githubusercontent.com/5554127/30042612-f5cb7a4c-9224-11e7-81a6-917aeda752a6.png)

Would you mind if i use the Chinese title:

![2017-09-05 10 28 06](https://user-images.githubusercontent.com/5554127/30042616-fc9645aa-9224-11e7-9c58-f98cafcf9348.png)

It looks better and is easier to attract the Chinese people's attention. If you agree, I'll change the title to Chinese.