### PR TITLE
Sort projects alphabetically

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -24,7 +24,9 @@ data.items.sections.map do |section|
     <div class="js-grid grid">
   EOS
 
-  contents = section['items'].map do |item|
+  contents = section['items']
+              .sort { |a,b| a['name'] <=> b['name'] }
+              .map do |item|
     item_to_html(item)
   end.reduce('', :+).strip.to_s
 


### PR DESCRIPTION
## What ?
Sort project names alphabetically within their own categories

## Why ?
I feel like there needs to be a more neutral way to define which projects are on top. Nothing prevents people from always putting their projects on the top of the list, even though many of those are inactive / irrelevant at some point. 

This doesn't necessarily need to be merged - but it is at least a basic mechanism to determine projects are always displayed in some automated order.

This is a stepping stone to solve a bigger problem - putting the most active projects on top, so people get better discoverability of projects that are highly active. So, a better alternative to this would be to query the GitHub API and sort by number of Stargazers (descending ofc), but that is a bit beyond my Ruby knowledge (Could build it, but it wouldn't be pretty like someone who actually knows ruby) 

Would love any thoughts, especially from you - @ashfurrow