### PR TITLE
GitHub metadata and smarter sorting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'middleman'
+gem 'httparty'
+gem 'psych'
+gem 'colorize'
 
 # Publish to github pages
 gem 'middleman-gh-pages', git: 'https://github.com/josephholsten/middleman-gh-pages.git', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    colorize (0.8.1)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -43,6 +44,8 @@ GEM
     hitimes (1.2.3)
     hooks (0.4.1)
       uber (~> 0.0.14)
+    httparty (0.16.0)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     json (1.8.6)
     kramdown (1.9.0)
@@ -80,12 +83,14 @@ GEM
       sprockets-sass (~> 1.3.0)
     minitest (5.8.3)
     multi_json (1.11.2)
+    multi_xml (0.6.0)
     padrino-helpers (0.12.5)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.12.5)
       tilt (~> 1.4.1)
     padrino-support (0.12.5)
       activesupport (>= 3.1)
+    psych (3.0.2)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -120,8 +125,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  colorize
+  httparty
   middleman
   middleman-gh-pages!
+  psych
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ Website for projects that support RxSwift.
 
 ## Adding a new project
 
-The site is generated from [this file](https://github.com/RxSwiftCommunity/rxswiftcommunity.github.io/blob/source/data/items.yml); add new projects there in yaml format. If you get stuck, just open an issue!
+The site is generated from [this file](https://github.com/RxSwiftCommunity/rxswiftcommunity.github.io/blob/source/data/items.yml); add new projects there in YAML format.
+
+When adding a new GitHub repository, there is no need to manually set `stargazers`, `watchers` or `updated_at` since these are updated automatically. Your basic "item" should look like so and be added to the appropriate section:
+
+```yaml
+- name: YourProject
+  repo: YourOrganization/YourProject
+  description: A description of your project
+```
+
+If you get stuck, just open an issue!
 
 ## Contributing
 
@@ -20,8 +30,6 @@ The site is generated from [this file](https://github.com/RxSwiftCommunity/rxswi
 3. Run `bundle install`
 4. Use `middleman` and browse to [localhost:4567](localhost:4567) to preview changes.
 5. Open a PR 🎉  targeting the source branch
-
-To add a new project to the site, add it to the [`items.yml` file](https://github.com/RxSwiftCommunity/rxswiftcommunity.github.io/blob/source/data/items.yml). Let us know if you have any questions!
 
 ## Deploying
 

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,8 @@ end
 
 desc "Builds, then publishes"
 task :deploy do
-  sh "bundle exec rake publish BRANCH_NAME=master ALLOW_DIRTY=true"
+  sh "./scripts/github_fetch.rb" # Fetch GitHub-info and populate items.yml
+  sh "bundle exec rake publish BRANCH_NAME=master ALLOW_DIRTY=true" # Build & Deploy
 end
 
 task :default => [:lint_projects, :travis]

--- a/data/items.yml
+++ b/data/items.yml
@@ -1,160 +1,313 @@
+---
 sections:
-
-  - name: Apps Built with RxSwift
-    items:
-      - name: Eidolon
-        link: https://github.com/artsy/eidolon
-        description: Artsy's auction bidding kiosk is built with RxSwift and demonstrates some neat uses of the Swift type system.
-      - name: RxGitHub
-        link: https://github.com/oronbz/RxGithub
-        description: an example project to demonstrate dependency injection and Swinject in MVVM (Model-View-ViewModel) architecture with RxSwift and firebase.
-      - name: ReactiveWeatherExample
-        link: https://github.com/marinbenc/ReactiveWeatherExample
-        description: A simple iOS weather app using the MVVM pattern and RxSwift framework.
-      - name: TicTacToe
-        link: https://github.com/maartenschumacher/TicTacToe
-        description: Stateless Tic Tac Toe game with RxSwift.
-      - name: Simple MVVM Login Example
-        link: https://github.com/carlosypunto/ReallySimpleMVVMLoginExampleWithRxSwift
-        description: Simulation of a log in process using RxSwift and MVVM.
-      - name: Count It
-        link: https://github.com/PiXeL16/CountItApp
-        description: Never lose the count again. App with Apple Watch integration that lets you count anything.
-      - name: RxTodo
-        link: https://github.com/devxoul/RxTodo
-        description: iOS Todo Application with RxSwift + MVVM.
-      - name: Who To Follow
-        link: https://github.com/DTVD/The-introduction-to-RxSwift-you-have-been-missing
-        description: The introduction to RxSwift you've been missing, based on famous tutorial on RxJs.
-      - name: EventBlank
-        link: https://github.com/realm-demos/EventBlank
-        description: A template conference app, featuring real-time schedule and data changes & running on Realm 🚀
-
-  - name: RxSwift Abstractions
-    items:
-      - name: Action
-        link: https://github.com/RxSwiftCommunity/Action
-        description: Encapsulates an action to be performed, usually by a button press. Contains helpful extensions on a variety of UI classes.
-      - name: RxEasing
-        link: https://github.com/lintmachine/RxEasing
-        description: RxEasing provides a few utility functions for applying easing functions to RxSwift Observable streams.
-      - name: RxViewModel
-        link: https://github.com/RxSwiftCommunity/RxViewModel
-        description: RxViewModel is the marriage between MVVM and Rx extensions, inspired by ReactiveCocoa's RVMViewModel project.
-      - name: CollectionVariable
-        link: https://github.com/gitdoapp/CollectionVariable
-        description: RxSwift Variable designed for collections. It exposes a changes observable that notifies when items are inserted or removed from the collection.
-      - name: RxOptional
-        link: https://github.com/RxSwiftCommunity/RxOptional
-        description: RxSwift extentions for Swift optionals and "Occupiable" types.
-      - name: RxGesture
-        link: https://github.com/RxSwiftCommunity/RxGesture
-        description: RxSwift extentions for iOS/OSX that allow to easily observe gestures on any view.
-      - name: RxPermission
-        link: https://github.com/sunshinejr/RxPermission
-        description: RxSwift bindings for Permissions API in iOS.
-      - name: RxSegue
-        link: https://github.com/RxSwiftCommunity/RxSegue
-        description: Reactive generic segue, implemented with RxSwift.
-      - name: RxAutoUpdater
-        link: https://github.com/kciter/RxAutoUpdater
-        description: Auto update to data for UITableView/UICollectionView.
-      - name: RxFileMonitor
-        link: https://github.com/RxSwiftCommunity/RxFileMonitor
-        description: RxSwift wrapper around CoreFoundation file events (FSEvent).
-      - name: RxHttpClient
-        link: https://github.com/RxSwiftCommunity/RxHttpClient
-        description: Simple RxSwift wrapper around URLSession.
-      - name: RxPager
-        link: https://github.com/RxSwiftCommunity/RxPager
-        description: Simple Pager for RxSwift.
-      - name: RxTask
-        link: https://github.com/RxSwiftCommunity/RxTask
-        description: An RxSwift wrapper for running command line tasks via Foundation's Process.
-      - name: RxState
-        link: https://github.com/RxSwiftCommunity/RxState
-        description: A tiny library built on top of RxSwift and inspired by Redux that facilitates building Unidirectional Data Flow architecture.
-      - name: RxFacebook
-        link: https://github.com/sauravexodus/RxFacebook
-        description: RxSwift extensions for Facebook Login and Graph Requests
-      - name: RxFeedback
-        link: https://github.com/kzaher/RxFeedback
-        description: Feedback loops architecture for RxSwift
-      - name: RxAnimated
-        link: https://github.com/RxSwiftCommunity/RxAnimated
-        description: Animated RxCocoa bindings
-      - name: RxFlow
-        link: https://github.com/RxSwiftCommunity/RxFlow
-        description: RxFlow is a navigation framework for iOS applications based on a Reactive Flow Coordinator pattern.
-      - name: RxSwiftExt
-        link: https://github.com/RxSwiftCommunity/RxSwiftExt
-        description: A collection of Rx operators & tools not found in the core RxSwift distribution
-
-  - name: Projects that Extend Other Projects with RxSwift
-    items:
-      - name: Moya-ObjectMapper
-        link: https://github.com/ivanbruel/Moya-ObjectMapper
-        description: ObjectMapper bindings for Moya for easier JSON serialization, including RxSwift bindings.
-      - name: NSObject+Rx
-        link: https://github.com/RxSwiftCommunity/NSObject-Rx
-        description: Handy RxSwift extensions on NSObject, including rx_disposeBag.
-      - name: Parse-RxSwift
-        link: https://github.com/bluelinelabs/Parse-RxSwift
-        description: A collection of wrapper classes that allow you to use RxSwift Observers in place of Parse's callbacks.
-      - name: RxAlamofire
-        link: https://github.com/RxSwiftCommunity/RxAlamofire
-        description: RxSwift wrapper around the elegant HTTP networking in Swift Alamofire. It exposes network requests as observables that can be used with RxSwift.
-      - name: RxMKMapView
-        link: https://github.com/RxSwiftCommunity/RxMKMapView
-        description: RxMKMapView is a RxSwift wrapper for MKMapView (MapKit) delegate.
-      - name: RxNimble
-        link: https://github.com/RxSwiftCommunity/RxNimble
-        description: Nimble matchers for Observable types, built on top of RxBlocking.
-      - name: RxWebKit
-        link: https://github.com/RxSwiftCommunity/RxWebKit
-        description: RxWebKit is a RxSwift wrapper for WebKit.
-      - name: RxMediaPicker
-        link: https://github.com/ruipfcosta/RxMediaPicker
-        description: A reactive wrapper built around UIImagePickerController.
-      - name: RxMultipeer
-        link: https://github.com/RxSwiftCommunity/RxMultipeer
-        description: A testable RxSwift wrapper around MultipeerConnectivity.
-      - name: RxBluetoothKit
-        link: https://github.com/Polidea/RxBluetoothKit
-        description: iOS & OSX Bluetooth library for RxSwift.
-      - name: RxStarscream
-        link: https://github.com/RxSwiftCommunity/RxStarscream
-        description: A lightweight extension to subscribe Starscream websocket events with RxSwift.
-      - name: RxGoogleMaps
-        link: https://github.com/kciter/RxGoogleMaps
-        description: RxGoogleMaps is a RxSwift wrapper for GoogleMaps delegate.
-      - name: RxGRDB
-        link: https://github.com/RxSwiftCommunity/RxGRDB
-        description: Reactive extensions for SQLite
-      - name: RxRealm
-        link: https://github.com/RxSwiftCommunity/RxRealm
-        description: RxSwift extension for RealmSwift's types.
-      - name: RxRealmDataSources
-        link: https://github.com/RxSwiftCommunity/RxRealmDataSources
-        description: Bind easily table and collection views to RxRealm results.
-      - name: RxASDataSources
-        link: https://github.com/RxSwiftCommunity/RxASDataSources
-        description: RxDataSources for AsyncDisplayKit/Texture, wrapping ASTableNode & ASCollectionNode.
-
-  - name: Projects with RxSwift Extensions
-    items:
-      - name: Moya
-        link: https://github.com/Moya/Moya
-        description: Moya is a network abstraction layer built on top of Alamofire. It exposes network requests as observables that can be used with RxSwift.
-      - name: SugarRecord
-        link: https://github.com/SwiftReactive/SugarRecord
-        description: SugarRecord is a CoreData/Realm wrapper. It exposes storage operations and fetches as observables to be used with RxSwift.
-      - name: ReactiveCommander
-        link: https://github.com/SwiftReactive/ReactiveCommander
-        description: ReactiveCommander implements the Commands Pattern using NSOperation and NSOperationQueue extensions exposing a Reactive interface.
-
-  - name: Documentation & Resources
-    items:
-      - name: RxSwift 中文文档（非官方）
-        link: https://beeth0ven.github.io/RxSwift-Chinese-Documentation
-        description: An unofficial RxSwift Chinese documentation website which is published with Gitbook.
+- name: RxSwift Abstractions
+  items:
+  - name: Action
+    repo: RxSwiftCommunity/Action
+    description: Encapsulates an action to be performed, usually by a button press.
+      Contains helpful extensions on a variety of UI classes.
+    stargazers: 440
+    watchers: 45
+    updated_at: '2018-02-27T07:47:30Z'
+  - name: RxEasing
+    repo: lintmachine/RxEasing
+    description: RxEasing provides a few utility functions for applying easing functions
+      to RxSwift Observable streams.
+    stargazers: 4
+    watchers: 2
+    updated_at: '2017-07-20T03:14:57Z'
+  - name: RxViewModel
+    repo: RxSwiftCommunity/RxViewModel
+    description: RxViewModel is the marriage between MVVM and Rx extensions, inspired
+      by ReactiveCocoa's RVMViewModel project.
+    stargazers: 296
+    watchers: 32
+    updated_at: '2018-02-23T10:42:38Z'
+  - name: CollectionVariable
+    repo: gitdoapp/CollectionVariable
+    description: RxSwift Variable designed for collections. It exposes a changes observable
+      that notifies when items are inserted or removed from the collection.
+    stargazers: 28
+    watchers: 2
+    updated_at: '2017-08-12T04:09:03Z'
+  - name: RxOptional
+    repo: RxSwiftCommunity/RxOptional
+    description: RxSwift extentions for Swift optionals and "Occupiable" types.
+    stargazers: 373
+    watchers: 43
+    updated_at: '2018-02-25T10:32:24Z'
+  - name: RxGesture
+    repo: RxSwiftCommunity/RxGesture
+    description: RxSwift extentions for iOS/OSX that allow to easily observe gestures
+      on any view.
+    stargazers: 541
+    watchers: 46
+    updated_at: '2018-03-02T04:01:20Z'
+  - name: RxPermission
+    repo: sunshinejr/RxPermission
+    description: RxSwift bindings for Permissions API in iOS.
+    stargazers: 207
+    watchers: 9
+    updated_at: '2018-02-21T09:18:51Z'
+  - name: RxSegue
+    repo: RxSwiftCommunity/RxSegue
+    description: Reactive generic segue, implemented with RxSwift.
+    stargazers: 75
+    watchers: 35
+    updated_at: '2018-01-12T11:46:38Z'
+  - name: RxAutoUpdater
+    repo: kciter/RxAutoUpdater
+    description: Auto update to data for UITableView/UICollectionView.
+    stargazers: 19
+    watchers: 3
+    updated_at: '2017-07-20T03:17:58Z'
+  - name: RxFileMonitor
+    repo: RxSwiftCommunity/RxFileMonitor
+    description: RxSwift wrapper around CoreFoundation file events (FSEvent).
+    stargazers: 24
+    watchers: 4
+    updated_at: '2018-02-13T04:10:58Z'
+  - name: RxHttpClient
+    repo: RxSwiftCommunity/RxHttpClient
+    description: Simple RxSwift wrapper around URLSession.
+    stargazers: 17
+    watchers: 2
+    updated_at: '2018-02-10T21:29:22Z'
+  - name: RxPager
+    repo: RxSwiftCommunity/RxPager
+    description: Simple Pager for RxSwift.
+    stargazers: 30
+    watchers: 4
+    updated_at: '2018-02-06T11:25:23Z'
+  - name: RxTask
+    repo: RxSwiftCommunity/RxTask
+    description: An RxSwift wrapper for running command line tasks via Foundation's
+      Process.
+    stargazers: 11
+    watchers: 38
+    updated_at: '2017-10-30T03:52:36Z'
+  - name: RxState
+    repo: RxSwiftCommunity/RxState
+    description: A tiny library built on top of RxSwift and inspired by Redux that
+      facilitates building Unidirectional Data Flow architecture.
+    stargazers: 88
+    watchers: 6
+    updated_at: '2018-02-14T00:35:28Z'
+  - name: RxFacebook
+    repo: sauravexodus/RxFacebook
+    description: RxSwift extensions for Facebook Login and Graph Requests
+    stargazers: 2
+    watchers: 1
+    updated_at: '2017-12-08T21:10:47Z'
+  - name: RxFeedback
+    repo: kzaher/RxFeedback
+    description: Feedback loops architecture for RxSwift
+    stargazers: 483
+    watchers: 25
+    updated_at: '2018-02-28T13:04:08Z'
+  - name: RxAnimated
+    repo: RxSwiftCommunity/RxAnimated
+    description: Animated RxCocoa bindings
+    stargazers: 355
+    watchers: 12
+    updated_at: '2018-02-28T11:43:09Z'
+  - name: RxFlow
+    repo: RxSwiftCommunity/RxFlow
+    description: RxFlow is a navigation framework for iOS applications based on a
+      Reactive Flow Coordinator pattern.
+    stargazers: 673
+    watchers: 21
+    updated_at: '2018-03-02T08:23:03Z'
+  - name: RxSwiftExt
+    repo: RxSwiftCommunity/RxSwiftExt
+    description: A collection of Rx operators & tools not found in the core RxSwift
+      distribution
+    stargazers: 424
+    watchers: 41
+    updated_at: '2018-02-28T14:37:00Z'
+- name: Projects that Extend Other Projects with RxSwift
+  items:
+  - name: Moya-ObjectMapper
+    repo: ivanbruel/Moya-ObjectMapper
+    description: ObjectMapper bindings for Moya for easier JSON serialization, including
+      RxSwift bindings.
+    stargazers: 329
+    watchers: 8
+    updated_at: '2018-03-01T13:59:57Z'
+  - name: NSObject+Rx
+    repo: RxSwiftCommunity/NSObject-Rx
+    description: Handy RxSwift extensions on NSObject, including rx_disposeBag.
+    stargazers: 285
+    watchers: 37
+    updated_at: '2018-03-01T04:07:08Z'
+  - name: Parse-RxSwift
+    repo: bluelinelabs/Parse-RxSwift
+    description: A collection of wrapper classes that allow you to use RxSwift Observers
+      in place of Parse's callbacks.
+    stargazers: 32
+    watchers: 2
+    updated_at: '2017-10-26T20:44:18Z'
+  - name: RxAlamofire
+    repo: RxSwiftCommunity/RxAlamofire
+    description: RxSwift wrapper around the elegant HTTP networking in Swift Alamofire.
+      It exposes network requests as observables that can be used with RxSwift.
+    stargazers: 885
+    watchers: 61
+    updated_at: '2018-03-01T04:05:22Z'
+  - name: RxMKMapView
+    repo: RxSwiftCommunity/RxMKMapView
+    description: RxMKMapView is a RxSwift wrapper for MKMapView (MapKit) delegate.
+    stargazers: 54
+    watchers: 34
+    updated_at: '2018-02-12T17:20:12Z'
+  - name: RxNimble
+    repo: RxSwiftCommunity/RxNimble
+    description: Nimble matchers for Observable types, built on top of RxBlocking.
+    stargazers: 106
+    watchers: 6
+    updated_at: '2018-02-10T11:34:07Z'
+  - name: RxWebKit
+    repo: RxSwiftCommunity/RxWebKit
+    description: RxWebKit is a RxSwift wrapper for WebKit.
+    stargazers: 70
+    watchers: 39
+    updated_at: '2018-02-19T04:11:45Z'
+  - name: RxMediaPicker
+    repo: ruipfcosta/RxMediaPicker
+    description: A reactive wrapper built around UIImagePickerController.
+    stargazers: 100
+    watchers: 36
+    updated_at: '2018-02-07T15:27:54Z'
+  - name: RxMultipeer
+    repo: RxSwiftCommunity/RxMultipeer
+    description: A testable RxSwift wrapper around MultipeerConnectivity.
+    stargazers: 49
+    watchers: 5
+    updated_at: '2018-01-06T14:11:24Z'
+  - name: RxBluetoothKit
+    repo: Polidea/RxBluetoothKit
+    description: iOS & OSX Bluetooth library for RxSwift.
+    stargazers: 715
+    watchers: 29
+    updated_at: '2018-03-02T14:30:41Z'
+  - name: RxStarscream
+    repo: RxSwiftCommunity/RxStarscream
+    description: A lightweight extension to subscribe Starscream websocket events
+      with RxSwift.
+    stargazers: 62
+    watchers: 5
+    updated_at: '2018-02-17T13:47:59Z'
+  - name: RxGoogleMaps
+    repo: kciter/RxGoogleMaps
+    description: RxGoogleMaps is a RxSwift wrapper for GoogleMaps delegate.
+    stargazers: 20
+    watchers: 2
+    updated_at: '2017-09-20T15:30:22Z'
+  - name: RxGRDB
+    repo: RxSwiftCommunity/RxGRDB
+    description: Reactive extensions for SQLite
+    stargazers: 56
+    watchers: 4
+    updated_at: '2018-03-01T07:21:37Z'
+  - name: RxRealm
+    repo: RxSwiftCommunity/RxRealm
+    description: RxSwift extension for RealmSwift's types.
+    stargazers: 611
+    watchers: 55
+    updated_at: '2018-03-03T03:55:01Z'
+  - name: RxRealmDataSources
+    repo: RxSwiftCommunity/RxRealmDataSources
+    description: Bind easily table and collection views to RxRealm results.
+    stargazers: 97
+    watchers: 9
+    updated_at: '2018-02-23T06:23:33Z'
+  - name: RxASDataSources
+    repo: RxSwiftCommunity/RxASDataSources
+    description: RxDataSources for AsyncDisplayKit/Texture, wrapping ASTableNode &
+      ASCollectionNode.
+    stargazers: 41
+    watchers: 4
+    updated_at: '2018-02-26T08:43:19Z'
+- name: Projects with RxSwift Extensions
+  items:
+  - name: Moya
+    repo: Moya/Moya
+    description: Moya is a network abstraction layer built on top of Alamofire. It
+      exposes network requests as observables that can be used with RxSwift.
+    stargazers: 8251
+    watchers: 220
+    updated_at: '2018-03-03T14:24:57Z'
+  - name: SugarRecord
+    repo: SwiftReactive/SugarRecord
+    description: SugarRecord is a CoreData/Realm wrapper. It exposes storage operations
+      and fetches as observables to be used with RxSwift.
+    stargazers: 1991
+    watchers: 63
+    updated_at: '2018-03-02T03:02:15Z'
+- name: Apps Built with RxSwift
+  items:
+  - name: Eidolon
+    repo: artsy/eidolon
+    description: Artsy's auction bidding kiosk is built with RxSwift and demonstrates
+      some neat uses of the Swift type system.
+    stargazers: 2166
+    watchers: 101
+    updated_at: '2018-03-03T18:10:33Z'
+  - name: RxGitHub
+    repo: oronbz/RxGithub
+    description: an example project to demonstrate dependency injection and Swinject
+      in MVVM (Model-View-ViewModel) architecture with RxSwift and firebase.
+    stargazers: 38
+    watchers: 3
+    updated_at: '2018-02-26T21:41:32Z'
+  - name: ReactiveWeatherExample
+    repo: marinbenc/ReactiveWeatherExample
+    description: A simple iOS weather app using the MVVM pattern and RxSwift framework.
+    stargazers: 181
+    watchers: 12
+    updated_at: '2018-02-27T11:55:53Z'
+  - name: TicTacToe
+    repo: maartenschumacher/TicTacToe
+    description: Stateless Tic Tac Toe game with RxSwift.
+    stargazers: 8
+    watchers: 3
+    updated_at: '2017-10-17T09:59:17Z'
+  - name: Simple MVVM Login Example
+    repo: carlosypunto/ReallySimpleMVVMLoginExampleWithRxSwift
+    description: Simulation of a log in process using RxSwift and MVVM.
+    stargazers: 74
+    watchers: 8
+    updated_at: '2018-02-04T15:35:27Z'
+  - name: Count It
+    repo: PiXeL16/CountItApp
+    description: Never lose the count again. App with Apple Watch integration that
+      lets you count anything.
+    stargazers: 46
+    watchers: 6
+    updated_at: '2018-02-05T04:05:51Z'
+  - name: RxTodo
+    repo: devxoul/RxTodo
+    description: iOS Todo Application with RxSwift + MVVM.
+    stargazers: 906
+    watchers: 35
+    updated_at: '2018-03-02T06:23:47Z'
+  - name: Who To Follow
+    repo: DTVD/The-introduction-to-RxSwift-you-have-been-missing
+    description: The introduction to RxSwift you've been missing, based on famous
+      tutorial on RxJs.
+    stargazers: 317
+    watchers: 11
+    updated_at: '2018-03-03T06:32:16Z'
+  - name: EventBlank
+    repo: realm-demos/EventBlank
+    description: "A template conference app, featuring real-time schedule and data
+      changes & running on Realm \U0001F680"
+    stargazers: 43
+    watchers: 8
+    updated_at: '2018-01-29T16:40:22Z'
+- name: Documentation & Resources
+  items:
+  - name: RxSwift 中文文档（非官方）
+    link: https://beeth0ven.github.io/RxSwift-Chinese-Documentation
+    description: An unofficial RxSwift Chinese documentation website which is published
+      with Gitbook.

--- a/lib/custom_helpers.rb
+++ b/lib/custom_helpers.rb
@@ -2,13 +2,15 @@ module CustomHelpers
 
   def item_to_html(item_hash)
     name = item_hash['name']
-    link = item_hash['link']
+    link = item_hash['link'] || "https://github.com/#{item_hash['repo']}"
+
     description = item_hash['description']
     <<-EOS
       <div class="js-grid-item grid-item">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h4 class="project-title"><a href="#{link}">#{name}</a></h4>
+            <h4 class="project-title"><a href="#{link}" target="_blank">#{name}</a></h4>
+            #{item_to_github_html(item_hash)}
           </div>
           <div class="panel-body">
             <p>#{description}</p>
@@ -18,4 +20,30 @@ module CustomHelpers
     EOS
   end
 
+  def item_to_github_html(item_hash)
+    if item_hash.key?('stargazers') then
+      stargazers = item_hash['stargazers']
+      watchers = item_hash['watchers']
+      date = Time.parse(item_hash['updated_at'])
+
+      html = <<-EOS
+        <div class="gh-meta">
+          <div class="gh-item">
+            <svg height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"></path></svg>
+            <span class="text-raised-4">#{stargazers}</span>
+          </div>
+          <div class="gh-item">
+            <svg height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"></path></svg>
+            <span class="text-raised-4">#{watchers}</span>
+          </div>
+          <div class="gh-item">
+            <svg height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M8 13H6V6h5v2H8v5zM7 1C4.81 1 2.87 2.02 1.59 3.59L0 2v4h4L2.5 4.5C3.55 3.17 5.17 2.3 7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-.34.03-.67.09-1H.08C.03 7.33 0 7.66 0 8c0 3.86 3.14 7 7 7s7-3.14 7-7-3.14-7-7-7z"></path></svg>
+            <span class="text-raised-4">#{time_ago_in_words(date)} ago</span>
+          </div>
+        </div>
+      EOS
+    else
+      html = ""
+    end
+  end
 end

--- a/scripts/github_fetch.rb
+++ b/scripts/github_fetch.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+require 'httparty'
+require 'psych'
+require 'colorize'
+
+unless ENV.key?('GITHUB_CLIENT_ID') && ENV.key?('GITHUB_CLIENT_SECRET') then
+    puts "Please set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET environment variables".red
+    exit 1
+end
+
+begin
+    ITEMS_FILE = "data/items.yml"
+
+    yaml = Psych.load_file(ITEMS_FILE)
+    sections = yaml["sections"]
+
+    sections.each do |section| 
+        section["items"].each do |item|
+            # We only need to fetch meta information for GitHub's
+            # API if this is a GitHub repo. Otherwise, skip.
+            if item.key?("repo") then
+                repo = item["repo"]
+
+                gh_meta = HTTParty.get("https://api.github.com/repos/#{repo}?client_id=#{ENV['GITHUB_CLIENT_ID']}&client_secret=#{ENV['GITHUB_CLIENT_SECRET']}")
+                item["stargazers"] = gh_meta["stargazers_count"] || item["stargazers"]
+                item["watchers"] = gh_meta["subscribers_count"] || item["stargazers"]
+                item["updated_at"] = gh_meta["updated_at"] || item["updated_at"]
+
+                puts "#{repo} has #{item["stargazers"]} stargazers, #{item["watchers"]} watchers and was last updated on #{item["updated_at"]}".green
+            end
+        end
+    end
+
+    File.open("data/items.yml", 'w') do |file|
+        file.write(Psych.dump(yaml))
+    end
+rescue => e
+    puts "Failed building YAML file with GitHub meta data: #{e}".red
+    exit 1
+end

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -4,6 +4,9 @@ title: RxSwift Community Projects
 
 <%=
 
+time = Time.now
+@last_updated = time.strftime("%b #{time.day.ordinalize} %Y %H:%M")
+
 opener = <<-EOS
   <div class="row">
     <div class="col-lg-10 col-lg-offset-1">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -25,10 +25,20 @@ data.items.sections.map do |section|
   EOS
 
   contents = section['items']
-              .sort { |a,b| a['name'] <=> b['name'] }
-              .map do |item|
-    item_to_html(item)
-  end.reduce('', :+).strip.to_s
+              .sort { |a, b| 
+                # If this is a GitHub repo, sort by last update.
+                # Otherwise, sort alphabetically.
+                if a.key?("updated_at") && b.key?("updated_at") then
+                  date_a = Time.parse(a["updated_at"])
+                  date_b = Time.parse(b["updated_at"])
+
+                  date_b <=> date_a
+                else
+                  a['name'] <=> b['name']
+                end
+              }
+              .map do |item| item_to_html(item) end
+              .reduce('', :+).strip.to_s
 
   opener + header + contents + closer
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -41,11 +41,16 @@
       <%= yield %>
 
       <!-- Footer -->
-      <footer>
+      <footer class="text-center">
         <div class="row">
           <div class="col-lg-12">
             <hr>
-            <p>This webpage is <a href="https://github.com/RxSwiftCommunity/rxswiftcommunity.github.io">open source</a> and we <a href="https://github.com/RxSwiftCommunity/contributors">welcome contributions</a>.</p>
+            <p>
+              This webpage is <a href="https://github.com/RxSwiftCommunity/rxswiftcommunity.github.io">open source</a> and we <a href="https://github.com/RxSwiftCommunity/contributors">welcome contributions</a>.<br />
+              <svg height="24" version="1.1" viewBox="0 0 16 16" width="24"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg> 
+              <span class="text-raised-6">GitHub-related information last updated on <%= @last_updated %></span>
+            </p>
+            
           </div>
         </div>
       </footer>

--- a/source/stylesheets/app.scss
+++ b/source/stylesheets/app.scss
@@ -10,3 +10,23 @@
 
 // Page chrome
 @import "chrome/anchors";
+
+// General styles
+.gh-meta {
+    display: inline-block;
+    
+    .gh-item {
+        float: left;
+        margin-right: 8px;
+    }
+}
+
+.text-raised-4 {
+    position: relative;
+    top: -4px;
+}
+
+.text-raised-6 {
+    position: relative;
+    top: -6px;
+}


### PR DESCRIPTION
This PR aims to add Stargazers, Watchers and Last updated date to every repository-backed entry.

It does this using [a script](https://github.com/RxSwiftCommunity/rxswiftcommunity.github.io/pull/67/files#diff-b2ff59b86fbe6aeea4262e4bd1f0ccf2) (which we'll later run nightly on Travis and on every PR) to fetch the relevant GitHub meta data and re-populate the **items.yml** file with that extra data. 

It also separates GitHub-related links (which are 99%) with just standard links by using `repo: org/repo` vs `link: https://arbitrary.link.com`, you can see this [here](https://github.com/RxSwiftCommunity/rxswiftcommunity.github.io/pull/67/files#diff-aad36bf084c15bc27d671316ae2d4387R20) vs. [here](https://github.com/RxSwiftCommunity/rxswiftcommunity.github.io/pull/67/files#diff-aad36bf084c15bc27d671316ae2d4387R311). 

Now that we have this information, we not only present it, but also sort the information presented accordingly. I initially thought to sort by `stargazers + watchers` but when thinking about it realized its more appropriate to sort by `updated_at` to keep more active repos on top.

Ruby isn't my strong suite but I think this is relatively OK, would love any feedback of course :)

The result looks something like this:
<img width="985" alt="4f081768-4cdb-4440-b361-c9cfb56683cd" src="https://user-images.githubusercontent.com/605076/36941157-a9c6e68c-1f22-11e8-84f8-da3d80d28dcc.png">

Closes #62.

Cheers 🍺 
Shai