### PR TITLE
New Section: Contribution needed.

### DIFF
--- a/data/items.yml
+++ b/data/items.yml
@@ -47,10 +47,6 @@ sections:
     repo: RxSwiftCommunity/RxTask
     description: An RxSwift wrapper for running command line tasks via Foundation's
       Process.
-  - name: RxState
-    repo: RxSwiftCommunity/RxState
-    description: A tiny library built on top of RxSwift and inspired by Redux that
-      facilitates building Unidirectional Data Flow architecture.
   - name: RxFeedback
     repo: kzaher/RxFeedback
     description: Feedback loops architecture for RxSwift
@@ -176,3 +172,14 @@ sections:
     link: https://beeth0ven.github.io/RxSwift-Chinese-Documentation
     description: An unofficial RxSwift Chinese documentation website which is published
       with Gitbook.
+      
+- name: Want to contribute? These repositories are in need of an update!
+  items:
+  - name: RxMediaPicker
+    repo: RxSwiftCommunity/RxMediaPicker
+    description: A reactive wrapper built around UIImagePickerController.
+  - name: RxState
+    repo: RxSwiftCommunity/RxState
+    description: A tiny library built on top of RxSwift and inspired by Redux that
+      facilitates building Unidirectional Data Flow architecture.
+    


### PR DESCRIPTION
During my journey through RxSwift I had the challenge to work with web sockets in a professional project. I found RxStarscream on github and then I saw it wasn't ready for RxSwift 4 and Swift 4.
I saw Shai was the one responsible for the latests updates and decided to talk with him, asking permissions to update it. Oh well, I've managed to do it with his help in later stages (code review and CI) and it was also my first contribution to anything outside of personal projects of mine. I've managed to learn more about DelegateProxy and CircleCi while establishing contact with Shai.

Where do I want to get?
There are some repositories in need of people to update them, share and learn in the process. I think that with this section we could highlight repositories that are with issues and others that might need an upgrade for Swift 4 for example (and if the tradition stays the same, Swift 5 later this year 🎉 ). Old code is a problem and I think we should try to avoid losing frameworks like ImagePicker during Swift's evolution.

