### PR TITLE
Add RxContacts

### DIFF
--- a/data/items.yml
+++ b/data/items.yml
@@ -6,6 +6,9 @@ sections:
     repo: RxSwiftCommunity/Action
     description: Encapsulates an action to be performed, usually by a button press.
       Contains helpful extensions on a variety of UI classes.
+  - name: RxContacts
+    repo: RxSwiftCommunity/RxContacts
+    description: RxContacts is a RxSwift wrapper around the Contacts Framework. 
   - name: RxEasing
     repo: lintmachine/RxEasing
     description: RxEasing provides a few utility functions for applying easing functions

--- a/data/items.yml
+++ b/data/items.yml
@@ -6,9 +6,6 @@ sections:
     repo: RxSwiftCommunity/Action
     description: Encapsulates an action to be performed, usually by a button press.
       Contains helpful extensions on a variety of UI classes.
-  - name: RxContacts
-    repo: RxSwiftCommunity/RxContacts
-    description: RxContacts is a RxSwift wrapper around the Contacts Framework. 
   - name: RxEasing
     repo: lintmachine/RxEasing
     description: RxEasing provides a few utility functions for applying easing functions
@@ -138,6 +135,9 @@ sections:
   - name: RxKingfisher
     repo: RxSwiftCommunity/RxKingfisher
     description: Reactive extension for the Kingfisher image downloading and caching library.
+  - name: RxContacts
+    repo: RxSwiftCommunity/RxContacts
+    description: RxContacts is a RxSwift wrapper around the Contacts Framework. 
 - name: Projects with RxSwift Extensions
   items:
   - name: Moya


### PR DESCRIPTION
The PR adds a new repo to the RxSwiftCommunity: RxContacts

RxContacts is a RxSwift wrapper around the Contacts Framework. 
- README is pretty complete
- the project is available with SPM, Carthage, and Cocoapods
- the copyright has been transferred to the RxSwiftCommunity

Thanks