### PR TITLE
Add RxReduce

### DIFF
--- a/data/items.yml
+++ b/data/items.yml
@@ -61,6 +61,10 @@ sections:
     repo: RxSwiftCommunity/RxFlow
     description: RxFlow is a navigation framework for iOS applications based on a
       Reactive Flow Coordinator pattern.
+  - name: RxReduce
+    repo: RxSwiftCommunity/RxReduce
+    description: RxReduce is a lightweight framework that ease the implementation 
+      of a state container pattern in a Reactive Programming compliant way.
   - name: RxSwiftExt
     repo: RxSwiftCommunity/RxSwiftExt
     description: A collection of Rx operators & tools not found in the core RxSwift


### PR DESCRIPTION
The PR adds a new repo to the RxSwiftCommunity: RxReduce.

RxReduce is an implementation of a State Container Architecture based on RxSwift.
See the README for more information.

- the README is pretty complete
- CI is based on travis-ci
- project is available with Carthage and Cocoapods
- the copyright has been transferred to the RxSwiftCommunity

Thanks.