### PR TITLE
Updated Moya-ObjectMapper to new repo transfer

### DIFF
--- a/data/items.yml
+++ b/data/items.yml
@@ -95,7 +95,7 @@ sections:
 - name: Projects that Extend Other Projects with RxSwift
   items:
   - name: Moya-ObjectMapper
-    repo: ivanbruel/Moya-ObjectMapper
+    repo: bmoliveira/Moya-ObjectMapper
     description: ObjectMapper bindings for Moya for easier JSON serialization, including
       RxSwift bindings.
   - name: NSObject+Rx


### PR DESCRIPTION
Moya-ObjectMapper was transferred to me and it wasn't updated accordingly.